### PR TITLE
feature/nuxt integration tests

### DIFF
--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -113,7 +113,7 @@ services:
     ports:
       - "3200:4000"
     restart: unless-stopped
-    command: npm run start
+    command: bash ./startup.sh
 
   # Selenium Server
   selenium-hub:

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -130,17 +130,15 @@ services:
     environment:
       - HUB_HOST=selenium-hub
       - HUB_PORT=4444
-      # BRUTE FORCE PROTECTION
-      - LOGIN_BLOCK_TIME=3
-  firefox:
-    image: selenium/node-firefox:3.141.59-titanium
-    volumes:
-      - /dev/shm:/dev/shm
-    depends_on:
-      - selenium-hub
-    environment:
-      - HUB_HOST=selenium-hub
-      - HUB_PORT=4444
+#   firefox:
+#     image: selenium/node-firefox:3.141.59-titanium
+#     volumes:
+#       - /dev/shm:/dev/shm
+#     depends_on:
+#       - selenium-hub
+#     environment:
+#       - HUB_HOST=selenium-hub
+#       - HUB_PORT=4444
 
 volumes:
   data-server-mongodb:

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -92,6 +92,28 @@ services:
     restart: unless-stopped
     command: npm run start
 
+  nuxtclient:
+    build:
+      context: ../nuxt-client
+      dockerfile: deploy/Dockerfile.client
+    depends_on:
+      - server
+      - client
+    environment:
+      # ENV
+      - NODE_ENV=production
+      - TZ=Europe/Berlin
+      - LEGACY_CLIENT_URL=http://client:3100
+      - API_URL=https://api.test.schul-cloud.org
+      # FEATURE TOGGLES
+      - FEATURE_TEAMS_ENABLED=true
+      # Theme and Titles
+      - SC_THEME=default
+    ports:
+      - \"3200:4000\"
+    restart: unless-stopped
+    command: npm run start
+
   # Selenium Server
   selenium-hub:
     image: selenium/hub:3.141.59-titanium

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -104,7 +104,8 @@ services:
       - NODE_ENV=production
       - TZ=Europe/Berlin
       - LEGACY_CLIENT_URL=http://client:3100
-      - API_URL=http://localhost:3030
+      - HOST=0.0.0.0
+      - API_URL=http://server:3030
       # FEATURE TOGGLES
       - FEATURE_TEAMS_ENABLED=true
       # Theme and Titles

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -95,7 +95,7 @@ services:
   nuxtclient:
     build:
       context: ../nuxt-client
-      dockerfile: deploy/Dockerfile.client
+      dockerfile: deploy/Dockerfile.client-test
     depends_on:
       - server
       - client
@@ -113,7 +113,7 @@ services:
     ports:
       - "3200:4000"
     restart: unless-stopped
-    command: bash ./startup.sh
+    command: npm run start
 
   # Selenium Server
   selenium-hub:

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -111,7 +111,7 @@ services:
       # Theme and Titles
       - SC_THEME=default
     ports:
-      - "3200:4000"
+      - "4000:4000"
     restart: unless-stopped
     command: npm run start
 

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -104,7 +104,7 @@ services:
       - NODE_ENV=production
       - TZ=Europe/Berlin
       - LEGACY_CLIENT_URL=http://client:3100
-      - API_URL=https://api.test.schul-cloud.org
+      - API_URL=http://localhost:3030
       # FEATURE TOGGLES
       - FEATURE_TEAMS_ENABLED=true
       # Theme and Titles

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -95,7 +95,7 @@ services:
   nuxtclient:
     build:
       context: ../nuxt-client
-      dockerfile: deploy/Dockerfile.client-test
+      dockerfile: deploy/Dockerfile.client
     depends_on:
       - server
       - client
@@ -113,7 +113,6 @@ services:
     ports:
       - "4000:4000"
     restart: unless-stopped
-    command: npm run start
 
   # Selenium Server
   selenium-hub:

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -110,7 +110,7 @@ services:
       # Theme and Titles
       - SC_THEME=default
     ports:
-      - \"3200:4000\"
+      - "3200:4000"
     restart: unless-stopped
     command: npm run start
 


### PR DESCRIPTION
## Description

- simplify travis.yml by using jobs and moving the integration-test setup [into a gist](https://gist.github.com/schul-cloud-bot/a849c38804174f99ca7818782bf03c00).
- add nuxt to the integration test setup

```bash
curl https://gist.githubusercontent.com/schul-cloud-bot/a849c38804174f99ca7818782bf03c00/raw/index.sh > integration-test.sh
chmod 700 integration-test.sh
bash integration-test.sh
```

related pulls:
- required to be merged at the same time
  - https://github.com/schul-cloud/docker-compose/pull/5
- optional, can also be merged later
  - https://github.com/schul-cloud/nuxt-client/pull/314
  - https://github.com/schul-cloud/schulcloud-client/pull/1457
